### PR TITLE
Replace torturous uses of sed with log | tail

### DIFF
--- a/git-back/git-back
+++ b/git-back/git-back
@@ -1,3 +1,2 @@
-# https://stackoverflow.com/questions/19936071/bash-get-first-word-last-line
-COMMIT_HASH=$(git log --oneline -n ${1:-2} | sed -n '$s/^\([^ ]*\).*$/\1/p') &&
+COMMIT_HASH=$(git log --format=%H -n ${1:-2} | tail -n 1) &&
 git checkout $COMMIT_HASH

--- a/git-backbase/git-backbase
+++ b/git-backbase/git-backbase
@@ -1,7 +1,5 @@
 git config --global submodule.recurse false
-# I fully admit that I borrow every 'sed' invocation from someone else.
-# https://stackoverflow.com/questions/19936071/bash-get-first-word-last-line
-COMMIT_HASH=$(git log --oneline -n $1 | sed -n '$s/^\([^ ]*\).*$/\1/p') &&
+COMMIT_HASH=$(git log --format=%H -n $1 | tail -n 1) &&
 # https://stackoverflow.com/questions/12394166/how-do-i-run-git-rebase-interactive-in-non-interactive-manner
 GIT_SEQUENCE_EDITOR="sed -i -re 's/^pick $COMMIT_HASH /e $COMMIT_HASH /'" git rebase -i HEAD~$1
 # sorry if this wasn't already your default!

--- a/git-drop/git-drop
+++ b/git-drop/git-drop
@@ -1,5 +1,3 @@
-# I fully admit that I borrow every 'sed' invocation from someone else.
-# https://stackoverflow.com/questions/19936071/bash-get-first-word-last-line
-COMMIT_HASH=$(git log --oneline -n $1 | sed -n '$s/^\([^ ]*\).*$/\1/p') &&
+COMMIT_HASH=$(git log --format=%H -n $1 | tail -n 1) &&
 # https://stackoverflow.com/questions/12394166/how-do-i-run-git-rebase-interactive-in-non-interactive-manner
 GIT_SEQUENCE_EDITOR="sed -i -re 's/^pick $COMMIT_HASH /e $COMMIT_HASH /'" git rebase -i HEAD~$1

--- a/git-stick/git-stick
+++ b/git-stick/git-stick
@@ -1,6 +1,4 @@
-# I fully admit that I borrow every 'sed' invocation from someone else.
-# https://stackoverflow.com/questions/19936071/bash-get-first-word-last-line
-COMMIT_HASH=$(git log --oneline -n $1 | sed -n '$s/^\([^ ]*\).*$/\1/p') &&
+COMMIT_HASH=$(git log --format=%H -n $1 | tail -n 1) &&
 git stash --include-untracked &&
 # https://stackoverflow.com/questions/12394166/how-do-i-run-git-rebase-interactive-in-non-interactive-manner
 GIT_SEQUENCE_EDITOR="sed -i -re 's/^pick $COMMIT_HASH /e $COMMIT_HASH /'" git rebase -i HEAD~$1 &&


### PR DESCRIPTION
Running `git log --oneline -n $COUNT` and then grabbing the sha from the
last line with sed is easier to read by adjusting the log format to
_only_ contain the hash and then just grabbing the last one with `tail`.